### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/viewflow/admin.py
+++ b/viewflow/admin.py
@@ -61,8 +61,8 @@ class TaskAdmin(admin.ModelAdmin):
         opts = self.model._meta
 
         return [
-            "admin/%s/%s/change_form.html" % (opts.app_label, opts.model_name),
-            "admin/%s/change_form.html" % opts.app_label,
+            "admin/{0!s}/{1!s}/change_form.html".format(opts.app_label, opts.model_name),
+            "admin/{0!s}/change_form.html".format(opts.app_label),
             'admin/viewflow/task/change_form.html'
         ]
 

--- a/viewflow/base.py
+++ b/viewflow/base.py
@@ -65,9 +65,9 @@ class Edge(object):
         return self._label
 
     def __str__(self):
-        edge = "[%s] %s ---> %s" % (self._edge_class, self._src, self._dst)
+        edge = "[{0!s}] {1!s} ---> {2!s}".format(self._edge_class, self._src, self._dst)
         if self._label:
-            edge += " (%s)" % self._label
+            edge += " ({0!s})".format(self._label)
         return edge
 
 
@@ -156,15 +156,15 @@ class _Resolver(object):
         elif isinstance(link, ThisObject):
             node = self.nodes.get(link.name)
             if not node:
-                raise ValueError("Can't found node with name %s" % link.name)
+                raise ValueError("Can't found node with name {0!s}".format(link.name))
             return node
         elif isinstance(link, str):
             node = self.nodes.get(link)
             if not node:
-                raise ValueError("Can't found node with name %s" % link)
+                raise ValueError("Can't found node with name {0!s}".format(link))
             return node
 
-        raise ValueError("Can't resolve %s" % link)
+        raise ValueError("Can't resolve {0!s}".format(link))
 
 
 class FlowMeta(object):

--- a/viewflow/compat.py
+++ b/viewflow/compat.py
@@ -120,7 +120,7 @@ except ImportError:
                     before_import_registry = copy.copy(register_to._registry)
 
                 try:
-                    import_module('%s.%s' % (app, module_to_search))
+                    import_module('{0!s}.{1!s}'.format(app, module_to_search))
                 except:
                     if register_to:
                         register_to._registry = before_import_registry
@@ -161,7 +161,7 @@ except ImportError:
 
     def manager_from_queryset(manager_cls, queryset_class, class_name=None):
         if class_name is None:
-            class_name = '%sFrom%s' % (manager_cls.__name__, queryset_class.__name__)
+            class_name = '{0!s}From{1!s}'.format(manager_cls.__name__, queryset_class.__name__)
         class_dict = {
             '_queryset_class': queryset_class,
         }

--- a/viewflow/templatetags/base.py
+++ b/viewflow/templatetags/base.py
@@ -71,7 +71,7 @@ def get_model_display_data(root_instance, user):
         # if any suitable for display children found
         if children:
             change_perm = get_permission_codename('change', root._meta)
-            if user.has_perm("%s.%s" % (root._meta.app_label, change_perm)):
+            if user.has_perm("{0!s}.{1!s}".format(root._meta.app_label, change_perm)):
                 admin_url_name = "admin:{}_{}_change".format(root._meta.app_label, root._meta.model_name)
                 try:
                     root_admin_url = reverse(admin_url_name, args=(root.pk,))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:viewflow?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:viewflow?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
